### PR TITLE
1.0.4

### DIFF
--- a/build/index.js
+++ b/build/index.js
@@ -434,7 +434,7 @@ var _default = (function () {
           if (err) {
             reject(new Error(err));
           } else {
-            resolve(_this10.sanitize(data));
+            resolve(_this10.sanitize(data.Item));
           }
         });
       });

--- a/src/index.js
+++ b/src/index.js
@@ -350,7 +350,7 @@ export default class {
         if (err) {
           reject(new Error(err));
         } else {
-          resolve(this.sanitize(data));
+          resolve(this.sanitize(data.Item));
         }
       });
     });

--- a/test/src/index.spec.js
+++ b/test/src/index.spec.js
@@ -104,6 +104,13 @@ describe('dynamo numeric tests', () => {
         done();
       });
     });
+
+    it('tests success from recreating test table again', (done) => {
+      numeric.createTableFromModel().then((data) => {
+        expect(data.existed).to.equal(true);
+        done();
+      });
+    });
   });
 
   describe('create', () => {


### PR DESCRIPTION
- Fixes for enforcing version control.
- Sanitize now works on getItemByHash
- Create table now does a list tables first to see if a table exists so create fails gracefully
- Validate moved ahead of createParams in putitem so that schemas don't require TableName/Item as part of the schema