### PR TITLE
Update: Validate with hash, fail if changed

### DIFF
--- a/build/index.js
+++ b/build/index.js
@@ -476,12 +476,15 @@ var _default = (function () {
 
       // TODO : Implement validation
       return new Promise(function (resolve, reject) {
-        var hashkey = Object.keys(hashObject)[0];
-        if (updatedValuesArray[hashkey]) {
-          delete updatedValuesArray[hashkey];
+        var hashKey = Object.keys(hashObject)[0];
+        var validationErrors = _this11.validate(updatedValuesArray, Object.keys(_this11.schemas)[0]);
+        if (updatedValuesArray[hashKey]) {
+          if (updatedValuesArray[hashKey] !== hashObject[hashKey]) {
+            throw new Error('Cannot change primary hash key on update');
+          }
+          delete updatedValuesArray[hashKey];
         }
         var version = paramVersion === false ? _this11.defaultVersion : paramVersion;
-        var validationErrors = _this11.validate(updatedValuesArray, Object.keys(_this11.schemas)[0]);
         if (validationErrors) {
           reject(new Error(validationErrors));
         } else {

--- a/src/index.js
+++ b/src/index.js
@@ -384,12 +384,15 @@ export default class {
   update(hashObject, updatedValuesArray, paramVersion = false) {
     // TODO : Implement validation
     return new Promise((resolve, reject) => {
-      const hashkey = Object.keys(hashObject)[0];
-      if (updatedValuesArray[hashkey]) {
-        delete updatedValuesArray[hashkey];
+      const hashKey = Object.keys(hashObject)[0];
+      const validationErrors = this.validate(updatedValuesArray, Object.keys(this.schemas)[0]);
+      if (updatedValuesArray[hashKey]) {
+        if (updatedValuesArray[hashKey] !== hashObject[hashKey]) {
+          throw new Error('Cannot change primary hash key on update');
+        }
+        delete updatedValuesArray[hashKey];
       }
       const version = (paramVersion === false) ? this.defaultVersion : paramVersion;
-      const validationErrors = this.validate(updatedValuesArray, Object.keys(this.schemas)[0]);
       if (validationErrors) {
         reject(new Error(validationErrors));
       } else {

--- a/test/src/index.spec.js
+++ b/test/src/index.spec.js
@@ -403,6 +403,15 @@ describe('standard model', () => {
       });
     });
 
+    it('fails to update a changed primary hash key', (done) => {
+      standard.update({id: testAccount1.Item.id}, {id: 'baz', email: 'test@test.com', firstName: 'jeb'}).then(() => {
+        done(new Error('should have failed'));
+      }).catch((err) => {
+        expect(err).to.be.an.Error;
+        done();
+      });
+    });
+
     it('fails to update with invalid data', (done) => {
       standard.update({id: testAccount1.Item.id}, {email: 'test@test.com', failValidate: true}).then(done).catch((err) => {
         expect(err).to.be.an.instanceof(Error);


### PR DESCRIPTION
This allows update() to succeed even if the primary hash key is marked as required() in the Joi spec, while appropriately throwing an error if the programmer tries to change the value of that key through an update.

**NOTE:** I have no idea why this PR wants to change every line of these files. Did they have Windows line endings before? These lines look identical to me. I can delete this branch and recreate if I did something moronic.