### PR TITLE
Set a default limit of 1000 records for scan() and readPaginate()

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -210,17 +210,17 @@ export default class {
     return new Promise((resolve, reject) => {
       let opts = {};
       opts.version = options.version || false;
-      opts.limit = options.limit || false;
+      opts.limit = options.limit || 1000;
       opts.lastKey = options.lastKey || false;
       helpers.checkCreateTable(this, opts.version).then(() => {
         const version = (opts.version === false) ? this.defaultVersion : opts.version;
         const table = this.schemas[version].tableName;
-        let scanObject = {'TableName': table};
+        let scanObject = {
+          'TableName': table,
+          'Limit': opts.limit
+        };
         if (filterObject) {
           scanObject = this.createFilter(table, filterObject);
-        }
-        if (opts.limit) {
-          scanObject.Limit = opts.limit;
         }
         if (opts.lastKey) {
           try {
@@ -306,7 +306,7 @@ export default class {
     return new Promise((resolve, reject) => {
       let opts = {};
       opts.version = options.version || false;
-      opts.limit = options.limit || false;
+      opts.limit = options.limit || 1000;
       opts.lastKey = options.lastKey || false;
       helpers.checkCreateTable(this, opts.version).then(() => {
         const version = (opts.version === false) ? this.defaultVersion : opts.version;
@@ -318,11 +318,9 @@ export default class {
           KeyConditionExpression: key + ' = :hk_val',
           ExpressionAttributeValues: {
             ':hk_val': obj[key]
-          }
+          },
+          Limit: opts.limit
         };
-        if (opts.limit) {
-          params.Limit = opts.limit;
-        }
         if (opts.lastKey) {
           try {
             params.ExclusiveStartKey = JSON.parse(opts.lastKey);

--- a/src/index.js
+++ b/src/index.js
@@ -215,13 +215,12 @@ export default class {
       helpers.checkCreateTable(this, opts.version).then(() => {
         const version = (opts.version === false) ? this.defaultVersion : opts.version;
         const table = this.schemas[version].tableName;
-        let scanObject = {
-          'TableName': table,
-          'Limit': opts.limit
-        };
+        let scanObject = {'TableName': table};
         if (filterObject) {
           scanObject = this.createFilter(table, filterObject);
         }
+        // Set after createFilter() is called above
+        scanObject.Limit = opts.limit;
         if (opts.lastKey) {
           try {
             scanObject.ExclusiveStartKey = JSON.parse(opts.lastKey);

--- a/src/index.js
+++ b/src/index.js
@@ -320,6 +320,16 @@ export default class {
             ':hk_val': obj[key]
           }
         };
+        if (opts.limit) {
+          params.Limit = opts.limit;
+        }
+        if (opts.lastKey) {
+          try {
+            params.ExclusiveStartKey = JSON.parse(opts.lastKey);
+          } catch (err) {
+            reject(err);
+          }
+        }
         this.ddb.query(params, (err, data) => {
           if (err) {
             reject(err);


### PR DESCRIPTION
Closes #27 

Also, this adds missing logic to use `limit` and `lastKey` for `readPaginate()`. Those options were being captured from the params, but not actually passed through to AWS. Finally, tests were added or updated as necessary to keep coverage at 100%