### PR TITLE
Return array instead of object with Items key

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -232,7 +232,7 @@ export default class {
           if (err) {
             reject(err);
           } else {
-            resolve(res);
+            resolve(res.Items);
           }
         });
       });
@@ -337,8 +337,7 @@ export default class {
             _.each(response.Items, function(row) {
               returnValue.push(sanitize(row));
             });
-            response.Items = returnValue;
-            resolve(response);
+            resolve(returnValue);
           }
         });
       }).catch(reject);

--- a/test/src/index.spec.js
+++ b/test/src/index.spec.js
@@ -284,13 +284,13 @@ describe('dynamo numeric tests', () => {
     });
     it('reads by numeric secondary with limit', (done) => {
       numeric.readPaginate({'age': dbData.numericAccount.Item.age}, {version: 1, limit: 1}).then((data) => {
-        expect(data.Items.length).to.be.above(0);
+        expect(data.length).to.be.above(0);
         done();
       });
     });
     it('reads by numeric secondary with limit and lastKey', (done) => {
       numeric.readPaginate({'age': dbData.numericAccount.Item.age}, {limit: 1, lastKey: JSON.stringify(lastKey)}).then((data) => {
-        expect(data.Items.length).to.be.above(0);
+        expect(data.length).to.be.above(0);
         done();
       });
     });
@@ -301,7 +301,7 @@ describe('dynamo numeric tests', () => {
       });
     });
     it('fails read by numeric secondary with limit and lastKey', (done) => {
-      numeric.readPaginate({'age': dbData.numericAccount.Item.age}, {limit: 1, lastKey}).then(done).catch((err) => {
+      numeric.readPaginate({'age': dbData.numericAccount.Item.age}, {limit: 1, lastKey}).then(() => done()).catch((err) => {
         expect(err).to.be.an.instanceof(Error);
         done();
       });
@@ -352,49 +352,49 @@ describe('standard model', () => {
     });
     it('performs a generic scan', (done) => {
       standard.scan().then((data) => {
-        expect(data.Items.length).to.be.above(0);
+        expect(data.length).to.be.above(0);
         done();
       });
     });
     it('performs a generic scan with limit', (done) => {
       standard.scan(undefined, {version: 1, limit: 1}).then((data) => {
-        expect(data.Items.length).to.be.above(0);
+        expect(data.length).to.be.above(0);
         done();
       });
     });
     it('performs a generic scan with limit and lastKey', (done) => {
       standard.scan(undefined, {limit: 1, lastKey: JSON.stringify(lastKey)}).then((data) => {
-        expect(data.Items.length).to.be.above(0);
+        expect(data.length).to.be.above(0);
         done();
       });
     });
     it('scans dynamo with EQ', (done) => {
       standard.scan({email: {eq: 'ben@ben.com'}}).then((data) => {
-        expect(data.Items.length).to.be.above(0);
+        expect(data.length).to.be.above(0);
         done();
       }).catch(done);
     });
     it('scans dynamo with contains', (done) => {
       standard.scan({roles: {contains: 'qa_user'}}).then((data) => {
-        expect(data.Items.length).to.be.above(0);
+        expect(data.length).to.be.above(0);
         done();
       }).catch(done);
     });
     it('scans dynamo with in', (done) => {
       standard.scan({firstName: { in: ['Ben', 'Benji']}}).then((data) => {
-        expect(data.Items.length).to.be.above(0);
+        expect(data.length).to.be.above(0);
         done();
       }).catch(done);
     });
     it('scans dynamo with between', (done) => {
       standard.scan({age: { between: [18, 26]}}).then((data) => {
-        expect(data.Items.length).to.be.above(0);
+        expect(data.length).to.be.above(0);
         done();
       }).catch(done);
     });
     it('scans dynamo with multiple expression filter', (done) => {
       standard.scan({roles: {contains: 'qa_user'}, email: {eq: 'ben@ben.com'}}).then((data) => {
-        expect(data.Items.length).to.be.above(0);
+        expect(data.length).to.be.above(0);
         done();
       }).catch(done);
     });
@@ -405,7 +405,7 @@ describe('standard model', () => {
       });
     });
     it('fails a generic scan with limit and lastKey', (done) => {
-      standard.scan(undefined, {limit: 1, lastKey}).then(done).catch((err) => {
+      standard.scan(undefined, {limit: 1, lastKey}).then(() => done()).catch((err) => {
         expect(err).to.be.an.instanceof(Error);
         done();
       });


### PR DESCRIPTION
Adapter was returning data with array inside object with key `Items` on scans and reads. More consistent to simply return the array.