### PR TITLE
Remove helpers.checkCreateTable() calls from within 9 methods

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -33,7 +33,7 @@ helpers.checkCreateTable = (modelObj, paramVersion) => {
 
     // Get current list of tables to determine if table exists
     modelObj.ddb.listTables({}, (err, foundTables) => {
-      if (_.contains(foundTables.TableNames, modelObj.schemas[version].tableName)) {
+      if (foundTables && _.contains(foundTables.TableNames, modelObj.schemas[version].tableName)) {
         resolve();
       } else {
         modelObj.createTableFromModel(paramVersion).then(resolve).catch(reject);

--- a/test/src/index.spec.js
+++ b/test/src/index.spec.js
@@ -3,6 +3,7 @@
 const _ = require('lodash');
 import '../setup';
 import DynamoAdapter from '../../src/index.js';
+import { helpers } from '../../src/helpers.js';
 import { dbData } from './test-data';
 import { model, adapter, use } from 'modli';
 let dynamoConfig = {
@@ -505,6 +506,17 @@ describe('standard model', () => {
   });
 
   describe('autocreate coverage', () => {
+    before((done) => {
+      // Make sure table exists
+      helpers.checkCreateTable(numeric, false);
+      // Make sure table exists before trying to delete it, and then auto creating it again
+      helpers.checkCreateTable(standard, false).then(() => {
+        standard.deleteTable({TableName: dbData.testModel.tableName}).then(() => {
+          helpers.checkCreateTable(standard, false);
+          done();
+        });
+      });
+    });
     it('Fails to create on non-existent table', (done) => {
       numeric.deleteTable({TableName: dbData.testNumericModel.tableName}).then(() => {
         numeric.create(dbData.numericAccount.Item, '1').then((data) => {
@@ -515,15 +527,8 @@ describe('standard model', () => {
       });
     });
 
-    it('Successfully creates first account on tables from post', (done) => {
+    it('Successfully creates account on autocreated table', (done) => {
       standard.create(dbData.testAccount1.Item, '1').then((data) => {
-        expect(data).to.be.an.object;
-        done();
-      });
-    });
-
-    it('Successfully creates second account on autocreated table', (done) => {
-      standard.create(dbData.testAccount2.Item, '1').then((data) => {
         expect(data).to.be.an.object;
         done();
       });

--- a/test/src/index.spec.js
+++ b/test/src/index.spec.js
@@ -508,12 +508,14 @@ describe('standard model', () => {
   describe('autocreate coverage', () => {
     before((done) => {
       // Make sure table exists
-      helpers.checkCreateTable(numeric, false);
-      // Make sure table exists before trying to delete it, and then auto creating it again
-      helpers.checkCreateTable(standard, false).then(() => {
-        standard.deleteTable({TableName: dbData.testModel.tableName}).then(() => {
-          helpers.checkCreateTable(standard, false);
-          done();
+      helpers.checkCreateTable(numeric, false).then(() => {
+        // Make sure table exists before trying to delete it, and then auto creating it again
+        helpers.checkCreateTable(standard, false).then(() => {
+          standard.deleteTable({TableName: dbData.testModel.tableName}).then(() => {
+            helpers.checkCreateTable(standard, false).then(() => {
+              done();
+            });
+          });
         });
       });
     });


### PR DESCRIPTION
Closes #30
Closes https://github.com/TechnologyAdvice/leadhub/issues/103

This fixes the `null` error within helpers.checkCreateTable() but also mainly removes helpers.checkCreateTable() from many method calls, and lastly updates tests.

**NOTE: I feel like this is going to be a BREAKING CHANGE (not for us) but for any open source user who has been depending on the `autoCreate` flag in the model to automatically create the tables for them when making any of the 9 method calls effected.** Instead, they will need to **explicitly** call helpers.checkCreateTable() at startup for each model to have it auto create the tables.